### PR TITLE
Read image from binary TCP stream

### DIFF
--- a/src/utils/tcp.py
+++ b/src/utils/tcp.py
@@ -1,17 +1,22 @@
 import socket
 import configparser
+import struct
 import threading
 
-# first message to the client is going to be a header thats 64 in length
-CONTENT_LENGTH_HEADER = 64 # a number that represents the length of content being recieved
+# first message to the client is going to be a header thats 8 in length
 FORMAT = 'utf-8'
 DISCONNECT_MESSAGE="!DISCONNECT"
+PACKET_HEADER_FORMAT = '<IBBBB'
+PACKET_HEADER_SIZE = struct.calcsize(PACKET_HEADER_FORMAT)
+IMAGE_MSG = 1
+IMAGE_MSG_HEADER_FORMAT = '<iiffIBB'
+IMAGE_MSG_HEADER_SIZE = struct.calcsize(IMAGE_MSG_HEADER_FORMAT)
 
 class TCPListen:
     def __init__(self, cfg):
         self.config = cfg
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-       
+
     def listen(self):
         # binding to localhost is supposedly faster as it bypasses some platform networking code.
         # however, to be seen externally, we need to bind to host: 0.0.0.0
@@ -20,34 +25,76 @@ class TCPListen:
 
         self.sock.bind((host, int(port)))
         self.sock.listen(5) # queue up 5 connect requests max. this is standard max, we shouldn't need more than this, probably less
-        
+
         print(f"listening on {host, port}")
 
         while True:
             self.accept_wrapper(self.sock)
+
+    # returns None if failed to read full length
+    def recv_all(conn, length):
+        data = bytearray(length)
+        view = memoryview(data)
+        bytes_received = 0
+        while bytes_received < length:
+            n = conn.recv_into(view[bytes_received:], length - bytes_received)
+            if n == 0:  # connection closed early
+                return None
+            bytes_received += n
+        return bytes(data)  # full buffer guaranteed
 
     def handle_client(self, conn, addr):
         try:
             # this will run concurrently
             print(f"New connection {addr} connected")
 
-            connected = True
-            while connected:
-                msg_length = conn.recv(CONTENT_LENGTH_HEADER).decode(FORMAT) # blocking
-                
-                if msg_length:
-                    msg_length = int(msg_length)
-                    msg = conn.recv(msg_length).decode(FORMAT) # blocking
+            while True:
+                header = self.recv_all(conn, PACKET_HEADER_SIZE) # blocking
+                if header is None:
+                    print(f"Failed to read header from {addr}")
+                    break
+                packet_length, msg_type, _, _, _ = struct.unpack(PACKET_HEADER_FORMAT, header)
 
-                    if msg == DISCONNECT_MESSAGE:
-                        connected = False
+                if msg_type == IMAGE_MSG:
+                    body_length = packet_length - PACKET_HEADER_SIZE
+                    if body_length < IMAGE_MSG_HEADER_SIZE:
+                        print(f"IMAGE packet is smaller than image header from {addr}")
+                        break
 
-                    print(f"[{addr}]: message length {msg_length}, {msg}")
-                
+                    body = self.recv_all(conn, body_length)
+                    if body is None:
+                        print(f"Failed to read full IMAGE body from {addr}")
+                        break
+
+                    (
+                        image_width, image_height, confidence_threshold, iou_threshold,
+                        image_length, image_name_length, model_name_length
+                    ) = struct.unpack_from(IMAGE_MSG_HEADER_FORMAT, body, 0)
+
+                    offset = IMAGE_MSG_HEADER_SIZE
+                    image = body[offset:offset+image_length]
+                    offset += image_length
+                    image_name = body[offset:offset+image_name_length].decode(FORMAT)
+                    offset += image_name_length
+                    model_name = body[offset:offset+model_name_length].decode(FORMAT)
+                    offset += model_name_length
+
+                    # TODO: process image here
+                else:
+                    # default case. Read the full packet and ignore it.
+                    print(f"Received message type {msg_type} not handled")
+                    body_length = packet_length - PACKET_HEADER_SIZE
+                    body = self.recv_all(conn, body_length)
+                    if body is None:
+                        print(f"Failed to read full body from {addr}")
+                        break
+                    continue
+
+
         except Exception as e:
             raise Exception(f"something went wrong {e}")
         finally:
-            conn.close()            
+            conn.close()
 
     def accept_wrapper(self, sock):
         conn, addr = sock.accept() # blocking
@@ -56,4 +103,4 @@ class TCPListen:
         thread = threading.Thread(target=self.handle_client, args=(conn, addr))
         thread.start()
 
-        print(f"Active threads {threading.activeCount() - 1}")
+        print(f"Active threads {threading.active_count() - 1}")

--- a/src/utils/tcp.py
+++ b/src/utils/tcp.py
@@ -32,7 +32,7 @@ class TCPListen:
             self.accept_wrapper(self.sock)
 
     # returns None if failed to read full length
-    def recv_all(conn, length):
+    def recv_all(self, conn, length):
         data = bytearray(length)
         view = memoryview(data)
         bytes_received = 0
@@ -50,6 +50,7 @@ class TCPListen:
 
             while True:
                 header = self.recv_all(conn, PACKET_HEADER_SIZE) # blocking
+                print(header, PACKET_HEADER_SIZE)
                 if header is None:
                     print(f"Failed to read header from {addr}")
                     break
@@ -78,6 +79,9 @@ class TCPListen:
                     offset += image_name_length
                     model_name = body[offset:offset+model_name_length].decode(FORMAT)
                     offset += model_name_length
+
+                    print(image_width, image_height, confidence_threshold, iou_threshold, image_length, image_name_length, model_name_length)
+                    print(image_name, model_name)
 
                     # TODO: process image here
                 else:


### PR DESCRIPTION
An example of unpacking binary data from TCP stream. 

For production, a flatbuffer may be more appropriate for the image body. This is fine for comparing TCP overhead vs gRPC 